### PR TITLE
Reading wrong thing for response status

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -50,7 +50,7 @@ class Client
         $response = $this->request()
                          ->retry(3, 100, function ($exception, $request) {
                              // Handle token expiry.
-                             if ($exception instanceof IlluminateRequestException && $request->response->status === 401) {
+                             if ($exception instanceof IlluminateRequestException && $exception->response->status() === 401) {
                                  $request->withHeaders([
                                      'x-api-key' => $this->getToken(true),
                                  ]);


### PR DESCRIPTION
https://laravel.com/docs/9.x/http-client#retries

The request parameter is pending, has no access to the response from the previous try. The exception has that response.